### PR TITLE
Fix: link redirecting to non existing google finance page

### DIFF
--- a/src/mainsite/components/PriceModel.tsx
+++ b/src/mainsite/components/PriceModel.tsx
@@ -78,6 +78,8 @@ const Marker: FC<MarkerProps> = ({ alt, icon, peRatio, symbol }) => {
             ? undefined
             : symbol === "DIS"
             ? "https://www.google.com/finance/quote/DIS:NYSE"
+            : symbol === "ETH
+            ? `https://www.google.com/finance/quote/ETH-USD`
             : `https://www.google.com/finance/quote/${symbol}:NASDAQ`
         }
         target="_blank"


### PR DESCRIPTION
Added ternary condition for identify ETH symbol and redirect to ETH-USD at google finance.